### PR TITLE
Presentation source fix

### DIFF
--- a/Sources/PresentationDefinition/PresentationDefinitionSource.swift
+++ b/Sources/PresentationDefinition/PresentationDefinitionSource.swift
@@ -24,7 +24,7 @@ public enum PresentationDefinitionSource {
 
 public extension PresentationDefinitionSource {
   init(authorizationRequestObject: JSON) throws {
-    if let presentationDefinitionObject = authorizationRequestObject[Constants.PRESENTATION_DEFINITION].dictionary {
+    if let presentationDefinitionObject = authorizationRequestObject[Constants.PRESENTATION_DEFINITION].dictionaryObject {
 
       let jsonData = try JSONSerialization.data(withJSONObject: presentationDefinitionObject, options: [])
       let presentationDefinition = try JSONDecoder().decode(PresentationDefinition.self, from: jsonData)


### PR DESCRIPTION
# Description of changes

Fixed an issue where an authorization request object should be used as a dictionary object.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes